### PR TITLE
Fix "speciesLocation" attribute in export recphyloxml

### DIFF
--- a/src/DTLGraph.cpp
+++ b/src/DTLGraph.cpp
@@ -2864,7 +2864,7 @@ string DTLGraph::getRecPhyloXMLReconciliation(
 			if(mSpeciesTree->getNodeById(lostSonX)->isLeaf())
 				idToPrintLoss=mSpeciesTree->getNodeById(lostSonX)->getName() ;
 			else
-				idToPrintLoss=bpp::TextTools::toString(mSpeciesTree->getNodeById(lostSonX)) ;
+				idToPrintLoss=bpp::TextTools::toString(mSpeciesTree->getNodeById(lostSonX)->getId()) ;
 			
 			geneTree_recPhyloXML_format = geneTree_recPhyloXML_format + idToPrintLoss;
 


### PR DESCRIPTION
Fixing recphyloxml output by giving the correct intern branch name during a `<loss>`  event if it's not a "leaf".